### PR TITLE
Add Plausible analytics script to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,10 +78,8 @@ launch_buttons:
 sphinx:
   config:
     html_js_files:
-      [
-        [ "https://plausible.io/js/script.js", { "defer": "defer", "data-domain": "simpeg.xyz" }, ],
-        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js",
-      ]
+      - [ "https://plausible.io/js/script.js", { "defer": "defer", "data-domain": "simpeg.xyz" }, ]
+      - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
 #   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
 #   local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
 #   config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/_config.yml
+++ b/_config.yml
@@ -78,7 +78,10 @@ launch_buttons:
 sphinx:
   config:
     html_js_files:
-    - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
+      [
+        [ "https://plausible.io/js/script.js", { "defer": "defer", "data-domain": "simpeg.xyz" }, ],
+        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js",
+      ]
 #   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
 #   local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
 #   config                    :   # key-value pairs to directly over-ride the Sphinx configuration


### PR DESCRIPTION
Enable Plausible analytics in SimPEG validation pages.

Fixes #1

For reference, I followed these instructions: https://jupyterbook.org/en/stable/advanced/html.html#use-plausible-analytics