### PR TITLE
Fix file names of images

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ SimPEG Code Validations Book
 The *SimPEG Code Validations Book* is a space for publishing notebooks used to validate the SimPEG coding package. The goal of this project is to assess the accuracy and benchmark the performance of SimPEG against analytic solutions and other coding packages.
 
 
-```{figure} ./assets/section_images/title_image.PNG
+```{figure} ./assets/section_images/title_image.png
 :width: 600px
 :align: center
 ```

--- a/notebooks/dcip_index.md
+++ b/notebooks/dcip_index.md
@@ -4,7 +4,7 @@ DC / IP
 In this chapter, we publish code comparisons and validations for direct current resistivity (DC) and induced polarization (IP) modeling packages.
 In SimPEG the *SimPEG.electromagnetics.static.resistivity* module is used for modeling DC resistivity data, while the *SimPEG.electromagnetics.static.induced_polarization* module is used for modeling IP data.
 
-```{figure} ../assets/section_images/dcip_physics.PNG
+```{figure} ../assets/section_images/dcip_physics.png
 :width: 800px
 :align: center
 

--- a/notebooks/fdem_index.md
+++ b/notebooks/fdem_index.md
@@ -4,7 +4,7 @@ Frequency-Domain Electromagnetics
 In this chapter, we publish code comparisons and validations for frequency-domain electromagnetic modeling packages.
 In SimPEG, the *SimPEG.electromagnetics.frequency_domain* module is used for modeling frequency-domain data.
 
-```{figure} ../assets/section_images/fem_physics.PNG
+```{figure} ../assets/section_images/fem_physics.png
 :width: 800px
 :align: center
 

--- a/notebooks/nsem_index.md
+++ b/notebooks/nsem_index.md
@@ -5,7 +5,7 @@ In this chapter, we publish code comparisons and validations for natural source 
 This includes magnetotellurics (MT) and Z-axis Tipper electromagnetics (ZTEM).
 In SimPEG, the *SimPEG.electromagnetics.natural_source* module is used for modeling natural source electromagnetic data.
 
-```{figure} ../assets/section_images/nsem_physics.PNG
+```{figure} ../assets/section_images/nsem_physics.png
 :width: 800px
 :align: center
 

--- a/notebooks/tdem_index.md
+++ b/notebooks/tdem_index.md
@@ -4,7 +4,7 @@ Time-Domain Electromagnetics
 In this chapter, we publish code comparisons and validations for time-domain electromagnetic modeling packages.
 In SimPEG, the *SimPEG.electromagnetics.time_domain* module is used for modeling time-domain data.
 
-```{figure} ../assets/section_images/tem_physics.PNG
+```{figure} ../assets/section_images/tem_physics.png
 :width: 800px
 :align: center
 


### PR DESCRIPTION
Respect the cases of the file names in Markdown files, otherwise `jupyter-book` fails to add the images on *nix systems.
